### PR TITLE
Clean up makefile and fix rst2html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
+.PHONY: default
+
 default:
-	make doc/plac.pdf
+	make doc/plac.pdf doc/plac.html
 doc/plac.pdf: doc/plac.rst doc/plac_core.rst doc/plac_adv.rst
-	cd doc; rst2pdf --footer=###Page### plac.rst; rst2html --stylesheet=$(HOME)/plac/df.css plac.rst plac.html
+	cd doc; rst2pdf --footer=###Page### plac.rst
+doc/plac.html:
+	cd doc; rst2html.py --stylesheet=../df.css plac.rst plac.html
 dist:
 	python3 setup.py build sdist bdist_wheel
 upload:
-	python3 setup.py register sdist bdist_wheel upload 
+	python3 setup.py register sdist bdist_wheel upload


### PR DESCRIPTION
On Linux systems, there is no `rst2html`, but `rst2html.py` should work pretty much everywhere.

This also separates the targets in the makefile.