### PR TITLE
Update readline() to work with Python 3

### DIFF
--- a/plac_ext.py
+++ b/plac_ext.py
@@ -53,6 +53,10 @@ else:
             raise exc.with_traceback(tb)
         raise exc
 
+try:
+    raw_input
+except NameError: # python 3
+    raw_input = input
 
 def decode(val):
     """
@@ -191,12 +195,7 @@ class ReadlineInput(object):
 
     def readline(self, prompt=''):
         try:
-            global input
-            input = raw_input
-        except NameError:
-            pass
-        try:
-            return input(prompt) + '\n'
+            return raw_input(prompt) + '\n'
         except EOFError:
             return ''
 

--- a/plac_ext.py
+++ b/plac_ext.py
@@ -191,7 +191,12 @@ class ReadlineInput(object):
 
     def readline(self, prompt=''):
         try:
-            return raw_input(prompt) + '\n'
+            global input
+            input = raw_input
+        except NameError:
+            pass
+        try:
+            return input(prompt) + '\n'
         except EOFError:
             return ''
 


### PR DESCRIPTION
raw_input() was renamed to input() in Python 3, causing NameError when trying to use interactive mode.