### PR TITLE
Fix default None value type inference (issue#34)

### DIFF
--- a/doc/test_plac.py
+++ b/doc/test_plac.py
@@ -205,6 +205,22 @@ def test_date_default():
     assert arg.day == datetime.date(2019, 11, 19)
 
 
+def test_int_default():
+    p = parser_from(lambda number=42: number)
+    arg = p.parse_args([])
+    assert arg.number == 42
+    arg = p.parse_args(['424242'])
+    assert arg.number == 424242
+
+
+def test_none_default():
+    p = parser_from(lambda nonable=None: arg)
+    arg = p.parse_args([])
+    assert arg.nonable is None
+    arg = p.parse_args(['somestring'])
+    assert arg.nonable == 'somestring'
+
+
 class Cmds(object):
     add_help = False
     commands = 'help', 'commit'

--- a/plac_core.py
+++ b/plac_core.py
@@ -278,7 +278,7 @@ class ArgumentParser(argparse.ArgumentParser):
                         a.type = to_datetime
                     elif isinstance(default, date):
                         a.type = to_date
-                    else:
+                    elif default is not None:
                         a.type = type(default)
             if a.kind in ('option', 'flag'):
                 if a.abbrev:


### PR DESCRIPTION
This fix issue #34 .

What happens with type inference from default in case of `None` is that `type(None) == NoneType` and `NoneType` doesn't take arguments:

```
>>> type(None)('value')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: NoneType takes no arguments
```

Perhaps a more elaborated/generic check could be done, such as inspecting the signature of `type(default)` and see if it expects an argument. But I believe this simple `is None` check is already enough for most cases, whereas the default `None` pattern is pretty common in python.
