### PR TITLE
Add python as language for code blocks on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Quickstart
 
 Here is a script that does some processing on a database table:
 
-.. code-block::
+.. code-block:: python
 
    # updatedb.py
    from datetime import datetime


### PR DESCRIPTION
A little cosmetic improvement to enable syntax highlighting on README.