### PR TITLE
Allow the use of reserved words as option or flag names

### DIFF
--- a/doc/example13.help
+++ b/doc/example13.help
@@ -1,0 +1,7 @@
+usage: example13.py [-h] [-d] [-g] [-s 100]
+
+optional arguments:
+  -h, --help         show this help message and exit
+  -d, --dry-run      [False]
+  -g, --global       [False]
+  -s 100, --sys 100  [100]

--- a/doc/example13.py
+++ b/doc/example13.py
@@ -1,0 +1,13 @@
+# example13.py
+import plac
+
+@plac.flg('global_')
+@plac.flg('dry_run')
+@plac.opt('sys_')
+def main(dry_run=False, global_=False, sys_=100):
+    print (dry_run)
+    print (global_)
+    print (sys_)
+
+if __name__ == '__main__':
+    plac.call(main)

--- a/doc/test_plac.py
+++ b/doc/test_plac.py
@@ -136,6 +136,12 @@ def test_p5():
     arg = p5.parse_args(['--dry-run'])
     assert arg.dry_run is True,  arg.dry_run
 
+p_global = parser_from(lambda reserved_=False: None, reserved_=('Reserved word', 'flag', 'g'))
+
+def test_global():
+    arg = p_global.parse_args(['--reserved'])
+    assert arg.reserved is True,  arg.reserved
+
 
 def test_flag_with_default():
     expect(TypeError, parser_from, lambda yes_or_no='no': None,

--- a/plac_core.py
+++ b/plac_core.py
@@ -271,7 +271,7 @@ class ArgumentParser(argparse.ArgumentParser):
             self.error(
                 _('colliding keyword arguments: %s') % ' '.join(collision))
         # Correct options with trailing undescores
-        args = [getattr(ns, a.strip('_')) for a in self.argspec.args]
+        args = [getattr(ns, a.rstrip('_')) for a in self.argspec.args]
         varargs = getattr(ns, self.argspec.varargs or '', [])
         return cmd, self.func(*(args + varargs + extraopts), **kwargs)
 
@@ -353,7 +353,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
                 if name.endswith("_"):
                     # Allows reserved words to be specified with underscore in name.
-                    suffix = name.strip('_')
+                    suffix = name.rstrip('_')
                 else:
                     # Convert undescores to dashes.
                     suffix = name.replace('_', '-')

--- a/plac_core.py
+++ b/plac_core.py
@@ -270,7 +270,8 @@ class ArgumentParser(argparse.ArgumentParser):
         if collision:
             self.error(
                 _('colliding keyword arguments: %s') % ' '.join(collision))
-        args = [getattr(ns, a) for a in self.argspec.args]
+        # Correct options with trailing undescores
+        args = [getattr(ns, a.strip('_')) for a in self.argspec.args]
         varargs = getattr(ns, self.argspec.varargs or '', [])
         return cmd, self.func(*(args + varargs + extraopts), **kwargs)
 
@@ -349,11 +350,19 @@ class ArgumentParser(argparse.ArgumentParser):
                 if not metavar and default == '':
                     metavar = "''"
             if a.kind in ('option', 'flag'):
+
+                if name.endswith("_"):
+                    # Allows reserved words to be specified with underscore in name.
+                    suffix = name.strip('_')
+                else:
+                    # Convert undescores to dashes.
+                    suffix = name.replace('_', '-')
+
                 if a.abbrev:
                     shortlong = (prefix + a.abbrev,
-                                 prefix*2 + name.replace('_', '-'))
+                                 prefix*2 + suffix)
                 else:
-                    shortlong = (prefix + name.replace('_', '-'),)
+                    shortlong = (prefix + suffix,)
             elif default is NONE:  # required argument
                 self.add_argument(name, help=a.help, type=a.type,
                                   choices=a.choices, metavar=metavar)


### PR DESCRIPTION
The changes permit the use of keywords and other language constructs to be used as option or flag names. 

The implementation is that trailing or leading underscores will be removed from the parameter names. Similar to how underscores are rewritten as dashes.

For example, a parameter called `global_` will present itself as `--global` or `list_` as `list`. This helps to break out of a limited vocabulary.

Example:

```
@plac.flg('global_')
@plac.flg('dry_run')
@plac.opt('sys_')
def main(dry_run=False, global_=False, sys_=100):
    print (dry_run)
    print (global_)
    print (sys_)

if __name__ == '__main__':
    plac.call(main)

```

the help will be:

```
usage: example13.py [-h] [-d] [-g] [-s 100]

optional arguments:
  -h, --help         show this help message and exit
  -d, --dry-run      [False]
  -g, --global       [False]
  -s 100, --sys 100  [100]
```

all test pass, a new test has been added.