### PR TITLE
Fix Tkinter imports on Python 3

### DIFF
--- a/doc/importer_ui.py
+++ b/doc/importer_ui.py
@@ -1,5 +1,9 @@
 from __future__ import with_statement
-from Tkinter import *
+import sys
+if sys.version_info < (3,):
+    from Tkinter import *
+else:
+    from tkinter import *
 from importer3 import FakeImporter
 
 def taskwidget(root, task, tick=500):

--- a/plac_tk.py
+++ b/plac_tk.py
@@ -3,11 +3,13 @@ import os
 import sys
 if sys.version_info < (3,):
     import Queue as queue
+    from Tkinter import Tk
+    from ScrolledText import ScrolledText
 else:
     import queue
+    from tkinter import Tk
+    from tkinter.scrolledtext import ScrolledText
 import plac_core
-from Tkinter import Tk
-from ScrolledText import ScrolledText
 from plac_ext import Monitor, TerminatedProcess
 
 


### PR DESCRIPTION
I didn’t attempt to test this interactively, but this at least allows `python3 -c 'import plac_tk'` to succeed.