### PR TITLE
Add Python 3.14+ support

### DIFF
--- a/doc/test_server.py
+++ b/doc/test_server.py
@@ -1,6 +1,9 @@
-import multiprocessing, subprocess, random, time
+import subprocess, random, time
 import plac
 from ishelve2 import ShelveInterface
+import multiprocessing as mp
+
+multiprocessing = mp.get_context("fork")
 
 i = plac.Interpreter(ShelveInterface(configfile=None))
 

--- a/plac_ext.py
+++ b/plac_ext.py
@@ -12,12 +12,13 @@ import subprocess
 import argparse
 import itertools
 import traceback
-import multiprocessing
+import multiprocessing as mp
 import signal
 import threading
 import plac_core
 
 version = sys.version_info[:2]
+multiprocessing = mp.get_context("fork")
 
 if version < (3, 5):
     from imp import load_source


### PR DESCRIPTION
In Python 3.14, the default start method for multiprocessing is now "forkserver".

https://docs.python.org/3/whatsnew/3.14.html#multiprocessing

Fixes: https://bugs.debian.org/1140949